### PR TITLE
Add packs directory to container

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ deployment:
     commands:
       - git clone --branch ${MASTODON_GIT_BRANCH:-master} ${MASTODON_GIT_URL:-https://github.com/tootsuite/mastodon.git}
       - docker build --tag mastodon mastodon
-      - docker run --env SECRET_KEY_BASE=dummy --volume $(pwd)/mastodon/public/assets:/mastodon/public/assets mastodon bundle exec rake assets:precompile
+      - docker run --env SECRET_KEY_BASE=dummy --volume $(pwd)/mastodon/public/assets:/mastodon/public/assets --volume $(pwd)/mastodon/public/packs:/mastodon/public/packs mastodon bundle exec rake assets:precompile
       - rm mastodon/.dockerignore
       - docker build --tag ${AWS_ECR_URL}:${CIRCLE_BUILD_NUM} mastodon
       - eval $(aws ecr get-login)


### PR DESCRIPTION
Lack of files in `#{Rails.root}/public/pack/*` occurs this error:

`ActionView::Template::Error (Can't find public.js in /mastodon/public/packs/manifest.json. Is webpack still compiling?):` 